### PR TITLE
Suggest isort configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ pre-commit = ["autohooks.plugins.isort"]
 include = ['foo/*.py', '*.foo']
 ```
 
+When using `autohooks-plugins-isort` in combination with
+[autohooks-plugin-isort](https://github.com/greenbone/autohooks-plugin-isort),
+the following configuration is recommended to ensure a consistent formatting:
+
+```toml
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 80
+```
+
 ## Maintainer
 
 This project is maintained by [Greenbone Networks GmbH](https://www.greenbone.net/).


### PR DESCRIPTION
Suggest `isort` settings for the `pyproject.toml` file to ensure
interoperability with `autohooks-plugin-black`.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] [CHANGELOG](https://github.com/greenbone/autohooks-plugin-isort/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
