### PR TITLE
Added dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect


### PR DESCRIPTION
Adding the dependabot.yml as it seems that dependabot is not working correct using the UI https://github.com/greenbone/autohooks-plugin-isort/issues/32
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] [CHANGELOG](https://github.com/greenbone/autohooks-plugin-isort/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
