### PR TITLE
Fix: fixes deprecated ruff command

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -20,6 +20,7 @@ jobs:
     uses: greenbone/workflows/.github/workflows/ci-python.yml@main
     with:
       lint-packages: autohooks tests
+      linter: ruff check
       python-version: ${{ matrix.python-version }}
 
 


### PR DESCRIPTION
## What

Fix: Use ruff check as linter

## Why

Using `ruff` is deprecated ...

## References

[DEVOPS-1093](https://jira.greenbone.net/browse/DEVOPS-1093)